### PR TITLE
Finish port to 1.19.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ build
 eclipse
 run
 /resourcepackcache/
+.DS_Store

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -32,7 +32,8 @@ dependencies {
     }
     modImplementation "com.terraformersmc:modmenu:${mod_menu_version}"
     implementation project(":Common")
-//    modImplementation "${compat_mod}${compat_fabric}"
+    modRuntimeOnly "${transparent_mod}${transparent_fabric}"
+    modRuntimeOnly "${ash_mod}${ash_fabric}"
 
     modApi group: 'com.electronwill.night-config', name: 'core', version: '3.6.5'//Used for Global Packs compat, Global Packs ships this
 }
@@ -101,16 +102,16 @@ publishing {
 }
 
 task publishCurseForge(type: TaskPublishCurseForge) {
+    if (project.hasProperty('api_token_paintings')) {
+        apiToken = "${api_token_paintings}"
 
-    apiToken = "${api_token_paintings}"
-
-    // The main file to upload
-    def mainFile = upload(252042, file("${project.buildDir}/libs/${archivesBaseName}-${version}.jar"))
-    mainFile.releaseType = 'beta'
-    mainFile.changelog = "${changelog}"
-    mainFile.changelogType = 'markdown'
-    mainFile.addRequirement('transparent')
-    mainFile.addRequirement('cloth-config')
-    mainFile.addRequirement('fabric-api')
-
+        // The main file to upload
+        def mainFile = upload(252042, file("${project.buildDir}/libs/${archivesBaseName}-${version}.jar"))
+        mainFile.releaseType = 'beta'
+        mainFile.changelog = "${changelog}"
+        mainFile.changelogType = 'markdown'
+        mainFile.addRequirement('transparent')
+        mainFile.addRequirement('cloth-config')
+        mainFile.addRequirement('fabric-api')
+    }
 }

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -90,9 +90,10 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compileOnly project(":Common")
     annotationProcessor 'org.spongepowered:mixin:0.8.4-SNAPSHOT:processor'
-//    runtimeOnly fg.deobf("${compat_mod}${compat_forge}")
-
+    runtimeOnly fg.deobf("${transparent_mod}${transparent_forge}")
+    runtimeOnly fg.deobf("${ash_mod}${ash_forge}")
 }
+
 repositories { //all of these are for adding crates compat
     mavenLocal()
     maven {
@@ -136,13 +137,14 @@ publishing {
 }
 
 task publishCurseForge(type: TaskPublishCurseForge) {
+    if (project.hasProperty('api_token_paintings')) {
+        apiToken = "${api_token_paintings}"
 
-    apiToken = "${api_token_paintings}"
-
-    // The main file to upload
-    def mainFile = upload(252042, jar)
-    mainFile.releaseType = 'beta'
-    mainFile.changelog = "${changelog}"
-    mainFile.changelogType = 'markdown'
-    mainFile.addRequirement('transparent')
+        // The main file to upload
+        def mainFile = upload(252042, jar)
+        mainFile.releaseType = 'beta'
+        mainFile.changelog = "${changelog}"
+        mainFile.changelogType = 'markdown'
+        mainFile.addRequirement('transparent')
+    }
 }

--- a/Forge/src/main/java/subaraki/paintings/datagen/Generator.java
+++ b/Forge/src/main/java/subaraki/paintings/datagen/Generator.java
@@ -1,6 +1,7 @@
 package subaraki.paintings.datagen;
 
-import net.minecraft.core.Registry;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.tags.PaintingVariantTagsProvider;
 import net.minecraft.resources.ResourceKey;
@@ -15,15 +16,21 @@ import subaraki.paintings.utils.PaintingPackReader;
 @Mod.EventBusSubscriber(modid = Paintings.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class Generator {
 
+    // Apologise if this doesn't work. I've never used Forge's data generators before, but it compiles.
     @SubscribeEvent
     public static void gatherData(GatherDataEvent event) {
         DataGenerator generator = event.getGenerator();
 
-        generator.addProvider(event.includeServer(), new PaintingVariantTagsProvider(generator, Paintings.MODID, event.getExistingFileHelper()) {
+        generator.addProvider(event.includeServer(), new PaintingVariantTagsProvider(
+                event.getGenerator().getPackOutput(),
+                event.getLookupProvider(),
+                Paintings.MODID,
+                event.getExistingFileHelper()
+        ) {
             @Override
-            protected void addTags() {
+            protected void addTags(HolderLookup.Provider provider) {
                 for (PaintingEntry entry : PaintingPackReader.PAINTINGS)
-                    this.tag(PaintingVariantTags.PLACEABLE).add(ResourceKey.create(Registry.PAINTING_VARIANT_REGISTRY, entry.getResLoc()));
+                    this.tag(PaintingVariantTags.PLACEABLE).add(ResourceKey.create(Registries.PAINTING_VARIANT, entry.getResLoc()));
             }
         });
     }

--- a/Forge/src/main/java/subaraki/paintings/mod/PackForcer.java
+++ b/Forge/src/main/java/subaraki/paintings/mod/PackForcer.java
@@ -1,11 +1,13 @@
 package subaraki.paintings.mod;
 
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.FilePackResources;
-import net.minecraft.server.packs.FolderPackResources;
 import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.PathPackResources;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraft.server.packs.repository.RepositorySource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -14,11 +16,6 @@ import subaraki.paintings.utils.PaintingPackReader;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.function.Consumer;
 
 @Mod.EventBusSubscriber(modid = Paintings.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -33,14 +30,34 @@ public class PackForcer implements RepositorySource {
     }
 
     @Override
-    public void loadPacks(Consumer<Pack> packConsumer, Pack.PackConstructor packBuilder) {
+    public void loadPacks(Consumer<Pack> packConsumer) {
         File dir = new File("./resourcepacks");
         if (dir.isDirectory()) {
             File[] fashionPacks = dir.listFiles(RESOURCEPACK_FILTER);
             if (fashionPacks != null)
                 for (File directory : fashionPacks) {
-                    Pack zipPack = Pack.create("file/" + directory.getName(), true, () -> new FilePackResources(directory), packBuilder, Pack.Position.TOP, PackSource.DEFAULT);
-                    Pack folderPack = Pack.create("file/" + directory.getName(), true, () -> new FolderPackResources(directory), packBuilder, Pack.Position.TOP, PackSource.DEFAULT);
+                    Pack zipPack = Pack.create(
+                            "file/" + directory.getName(),
+                            Component.literal(directory.getName()),
+                            true,
+                            id -> new FilePackResources(directory.getName(), directory, false),
+                            new Pack.Info(Component.empty(), 12, FeatureFlagSet.of()),
+                            PackType.CLIENT_RESOURCES,
+                            Pack.Position.TOP,
+                            false,
+                            PackSource.DEFAULT
+                    );
+                    Pack folderPack = Pack.create(
+                            "file/" + directory.getName(),
+                            Component.literal(directory.getName()),
+                            true,
+                            id -> new PathPackResources(directory.getName(), directory.toPath(), false),
+                            new Pack.Info(Component.empty(), 12, FeatureFlagSet.of()),
+                            PackType.CLIENT_RESOURCES,
+                            Pack.Position.TOP,
+                            false,
+                            PackSource.DEFAULT
+                    );
 
                     if (zipPack != null) {
                         packConsumer.accept(zipPack);

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,10 @@ mod_id=paintings
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 # compat with the 'transparent' mod
-#file id's from the cursemaven
-compat_mod=curse.maven:transparent-377582:
-compat_forge= 3834254
-compat_fabric=3834255
+transparent_mod=curse.maven:transparent-377582:
+transparent_forge= 4503226
+transparent_fabric=4503227
+# 'transparent' mod now requires ash-api
+ash_mod=curse.maven:ash-api-838498:
+ash_forge= 4505414
+ash_fabric=4505415


### PR DESCRIPTION
This PR finishes the work that @strikerrocker did on porting Paintings++ to 1.19.3.
Most of the changes are on Forge because strikerrocker ported the Fabric half.
I also added back the Transparent runtime dependency into the build scripts now that Transparent is available for 1.19.3.

I tested this PR on Forge and Fabric with a painting pack to make sure that painting pack loading works.

I did not up the version number because I'm not sure how you handle that.