### PR TITLE
Port to 1.19.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ build
 eclipse
 run
 /resourcepackcache/
+.DS_Store

--- a/Common/src/main/java/subaraki/paintings/event/ProcessInteractEvent.java
+++ b/Common/src/main/java/subaraki/paintings/event/ProcessInteractEvent.java
@@ -1,7 +1,7 @@
 package subaraki.paintings.event;
 
 import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
@@ -25,7 +25,7 @@ public class ProcessInteractEvent {
     }
 
     private static boolean equalNames(PaintingVariant a, PaintingVariant b) {
-        return Registry.PAINTING_VARIANT.getKey(a).equals(Registry.PAINTING_VARIANT.getKey(b));
+        return BuiltInRegistries.PAINTING_VARIANT.getKey(a).equals(BuiltInRegistries.PAINTING_VARIANT.getKey(b));
     }
 
     public static void processInteractPainting(Player player, Entity target, InteractionHand hand, SyncpacketSupplier syncpacketSupplier) {
@@ -39,21 +39,21 @@ public class ProcessInteractEvent {
 
                         // it is important to sort the paintings from big to small so all same size
                         // paintings will be next to one another
-                        List<ResourceLocation> validArtsArray = Registry.PAINTING_VARIANT.keySet().stream().filter(paintingRegistryName -> {
-                            return PaintingUtility.ART_COMPARATOR.compare(Registry.PAINTING_VARIANT.get(paintingRegistryName), original.value()) == 0;
+                        List<ResourceLocation> validArtsArray = BuiltInRegistries.PAINTING_VARIANT.keySet().stream().filter(paintingRegistryName -> {
+                            return PaintingUtility.ART_COMPARATOR.compare(BuiltInRegistries.PAINTING_VARIANT.get(paintingRegistryName), original.value()) == 0;
                         }).toList();
 
                         boolean takeNext = false;
                         for (ResourceLocation registryName : validArtsArray) {
-                            var variant = Registry.PAINTING_VARIANT.get(registryName);
-                            var regEntry = Registry.PAINTING_VARIANT.getResourceKey(variant);
+                            var variant = BuiltInRegistries.PAINTING_VARIANT.get(registryName);
+                            var regEntry = BuiltInRegistries.PAINTING_VARIANT.getResourceKey(variant);
 
                             if (equalSizes(original.value(), variant) && regEntry.isPresent()) {
                                 if (firstMatch == null) {
-                                    firstMatch = Registry.PAINTING_VARIANT.getHolderOrThrow(regEntry.get());
+                                    firstMatch = BuiltInRegistries.PAINTING_VARIANT.getHolderOrThrow(regEntry.get());
                                 }
                                 if (takeNext) {
-                                    newArt = Registry.PAINTING_VARIANT.getHolderOrThrow(regEntry.get());
+                                    newArt = BuiltInRegistries.PAINTING_VARIANT.getHolderOrThrow(regEntry.get());
                                     break;
                                 }
                                 if (equalNames(original.value(), variant)) {

--- a/Common/src/main/java/subaraki/paintings/event/ProcessPlacementEvent.java
+++ b/Common/src/main/java/subaraki/paintings/event/ProcessPlacementEvent.java
@@ -4,6 +4,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -67,6 +68,19 @@ public class ProcessPlacementEvent {
             return false;
 
         if (itemStack.getItem() == Items.PAINTING) {
+            // Check if the item has a painting variant in its nbt.
+            // If it does, don't perform painting++ behavior and default to vanilla painting placing behavior.
+            CompoundTag tag = itemStack.getTag();
+            if (tag != null && tag.contains("EntityTag", 10)) {
+                CompoundTag entityTag = tag.getCompound("EntityTag");
+                Optional<ResourceKey<PaintingVariant>> paintingVariantResourceKey = Painting.loadVariant(entityTag).flatMap(Holder::unwrapKey);
+                if (paintingVariantResourceKey.isPresent()) {
+                    PaintingVariant paintingVariant = BuiltInRegistries.PAINTING_VARIANT.get(paintingVariantResourceKey.get());
+                    if (paintingVariant != null) {
+                        return false;
+                    }
+                }
+            }
 
             BlockPos actualPos = blockPos.relative(face);
 

--- a/Common/src/main/java/subaraki/paintings/event/ProcessPlacementEvent.java
+++ b/Common/src/main/java/subaraki/paintings/event/ProcessPlacementEvent.java
@@ -3,7 +3,7 @@ package subaraki.paintings.event;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 public class ProcessPlacementEvent {
 
-    private static List<ResourceKey<PaintingVariant>> vanillaPaintings = new ArrayList<>();
+    private static final List<ResourceKey<PaintingVariant>> vanillaPaintings = new ArrayList<>();
 
     static {
         vanillaPaintings.add(PaintingVariants.KEBAB);
@@ -55,11 +55,11 @@ public class ProcessPlacementEvent {
         vanillaPaintings.add(PaintingVariants.PIGSCENE);
         vanillaPaintings.add(PaintingVariants.BURNING_SKULL);
         vanillaPaintings.add(PaintingVariants.SKELETON);
+        vanillaPaintings.add(PaintingVariants.DONKEY_KONG);
         vanillaPaintings.add(PaintingVariants.EARTH);
         vanillaPaintings.add(PaintingVariants.WIND);
         vanillaPaintings.add(PaintingVariants.FIRE);
         vanillaPaintings.add(PaintingVariants.WATER);
-        vanillaPaintings.add(PaintingVariants.DONKEY_KONG);
     }
 
     public static boolean processPlacementEvent(ItemStack itemStack, Player player, Direction face, BlockPos blockPos, Level level, PlacementPacketSupplier send) {
@@ -95,11 +95,11 @@ public class ProcessPlacementEvent {
 
                             // list of paintings placeable at current location
                             //takes registry names
-                            List<ResourceLocation> validArts = Registry.PAINTING_VARIANT.keySet().stream().filter(resourceLocation -> {
-                                var variant = Registry.PAINTING_VARIANT.get(resourceLocation);
-                                var regEntry = Registry.PAINTING_VARIANT.getResourceKey(variant);
+                            List<ResourceLocation> validArts = BuiltInRegistries.PAINTING_VARIANT.keySet().stream().filter(resourceLocation -> {
+                                var variant = BuiltInRegistries.PAINTING_VARIANT.get(resourceLocation);
+                                var regEntry = BuiltInRegistries.PAINTING_VARIANT.getResourceKey(variant);
                                 if (regEntry.isPresent()) {
-                                    ((IPaintingAccessor) paintingEntity).callSetVariant(Registry.PAINTING_VARIANT.getHolderOrThrow(regEntry.get()));
+                                    ((IPaintingAccessor) paintingEntity).callSetVariant(BuiltInRegistries.PAINTING_VARIANT.getHolderOrThrow(regEntry.get()));
                                     return paintingEntity.survives() && (!Services.CONFIG.useVanillaOnly() || vanillaPaintings.contains(regEntry.get()));
                                 }
                                 return false;
@@ -111,9 +111,9 @@ public class ProcessPlacementEvent {
                             Paintings.UTILITY.updatePaintingBoundingBox(paintingEntity); // reset bounding box
 
                             // sort paintings from high to low, and from big to small
-                            List<PaintingVariant> sorted = (validArts.stream().map(Registry.PAINTING_VARIANT::get).sorted(PaintingUtility.ART_COMPARATOR)).toList();
+                            List<PaintingVariant> sorted = (validArts.stream().map(BuiltInRegistries.PAINTING_VARIANT::get).sorted(PaintingUtility.ART_COMPARATOR)).toList();
                             //map resource<variant> to the registered resourcelocation
-                            List<ResourceLocation> references = sorted.stream().map(Registry.PAINTING_VARIANT::getKey).toList();
+                            List<ResourceLocation> references = sorted.stream().map(BuiltInRegistries.PAINTING_VARIANT::getKey).toList();
                             //Send packet to open gui
                             send.send((ServerPlayer) player, paintingEntity, references.toArray(ResourceLocation[]::new));
                         }

--- a/Common/src/main/java/subaraki/paintings/gui/CommonPaintingScreen.java
+++ b/Common/src/main/java/subaraki/paintings/gui/CommonPaintingScreen.java
@@ -4,10 +4,9 @@ import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
@@ -25,8 +24,6 @@ public class CommonPaintingScreen extends Screen implements IPaintingGUI {
     public static final int START_Y = 30;
     public static final int GAP = 5;
     private final int entityID;
-    private final Button defaultButton = new Button(0, 0, 0, 0, Component.literal("default"), button -> {
-    });
     private final PaintingVariant[] types;
     private int scrollBarScroll = 0;
 
@@ -66,7 +63,7 @@ public class CommonPaintingScreen extends Screen implements IPaintingGUI {
             }
             try {
                 this.addRenderableWidget(new PaintingButton(posx, posy, variant.getWidth(), variant.getHeight(), Component.literal(""), button -> {
-                    sendPacket(Registry.PAINTING_VARIANT.getKey(variant), entityID);
+                    sendPacket(BuiltInRegistries.PAINTING_VARIANT.getKey(variant), entityID);
                     this.removed();
                     this.onClose();
                 }, variant));
@@ -87,8 +84,8 @@ public class CommonPaintingScreen extends Screen implements IPaintingGUI {
     private void centerRow(int start, int end) {
 
         if (optionalAbstractWidget(start).isPresent() && optionalAbstractWidget(end).isPresent()) {
-            int left = this.optionalAbstractWidget(start).get().x;
-            int right = optionalAbstractWidget(end).get().x + optionalAbstractWidget(end).get().getWidth();
+            int left = this.optionalAbstractWidget(start).get().getX();
+            int right = optionalAbstractWidget(end).get().getX() + optionalAbstractWidget(end).get().getWidth();
 
             // We're 10 pixels away from each edge
             int correction = (width - 20 - (right - left)) / 2;
@@ -133,8 +130,8 @@ public class CommonPaintingScreen extends Screen implements IPaintingGUI {
 
             float move = (float) amountY * -1.0f;
 
-            int paintingCanvasTopY = (optionalFirstWidget().get().y);
-            int paintingCanvasBotY = (optionalLastWidget().get().y + optionalLastWidget().get().getHeight());
+            int paintingCanvasTopY = (optionalFirstWidget().get().getY());
+            int paintingCanvasBotY = (optionalLastWidget().get().getY() + optionalLastWidget().get().getHeight());
 
             int paintingContainerSize = paintingCanvasBotY - paintingCanvasTopY; //total height span of all shown paintings. gaps accounted for
             int viewport = height - (START_Y); //height of cutout rect in which paintings are shown
@@ -152,13 +149,13 @@ public class CommonPaintingScreen extends Screen implements IPaintingGUI {
 
     private void movePaintinWidgets(int scrollAmount) {
 
-        int paintingCanvasTopY = (optionalFirstWidget().get().y);
+        int paintingCanvasTopY = (optionalFirstWidget().get().getY());
         int onScreenTopLimit = GAP + START_Y; //relative screen position, first painting can only scroll up until here
-        int paintingCanvasBotY = (optionalLastWidget().get().y + optionalLastWidget().get().getHeight());
+        int paintingCanvasBotY = (optionalLastWidget().get().getY() + optionalLastWidget().get().getHeight());
         int onScreenBottomLimit = height - (onScreenTopLimit); //relative screen position, last painting can only scroll up until here
 
         if ((scrollAmount > 0 && paintingCanvasTopY < onScreenTopLimit) || (scrollAmount < 0 && paintingCanvasBotY >= onScreenBottomLimit)) {
-            getRenderablesWithCast().forEach(widget -> ((AbstractWidget) widget).y += scrollAmount);
+            getRenderablesWithCast().forEach(widget -> ((AbstractWidget) widget).setY(((AbstractWidget) widget).getY() + scrollAmount));
             scrollBarScroll -= scrollAmount;
         }
     }
@@ -167,7 +164,7 @@ public class CommonPaintingScreen extends Screen implements IPaintingGUI {
     private void drawToolTips(PoseStack mat, int mouseX, int mouseY) {
         if (!Services.CONFIG.showPaintingSize())
             return;
-        for (Widget guiButton : getRenderablesWithCast()) {
+        for (Renderable guiButton : getRenderablesWithCast()) {
             if (guiButton instanceof PaintingButton button) {
                 if (button.isMouseOver(mouseX, mouseY)) {
                     MutableComponent text = Component.literal(button.getWidth() / 16 + "x" + button.getHeight() / 16);
@@ -184,8 +181,8 @@ public class CommonPaintingScreen extends Screen implements IPaintingGUI {
         if (getRenderablesWithCast().isEmpty())
             return;
         if (optionalFirstWidget().isPresent() && optionalLastWidget().isPresent()) {
-            int top = optionalFirstWidget().get().y;
-            int bot = optionalLastWidget().get().y + optionalLastWidget().get().getHeight();
+            int top = optionalFirstWidget().get().getY();
+            int bot = optionalLastWidget().get().getY() + optionalLastWidget().get().getHeight();
             // get total size for buttons drawn
             int totalSize = (bot - top);
             int containerSize = (height - (START_Y * 2));
@@ -226,7 +223,7 @@ public class CommonPaintingScreen extends Screen implements IPaintingGUI {
     }
 
     @Override
-    public List<Widget> getRenderablesWithCast() {
+    public List<Renderable> getRenderablesWithCast() {
         throw new IllegalStateException("painting gui common code crash override. please override paintingscreen");
     }
 

--- a/Common/src/main/java/subaraki/paintings/gui/IPaintingGUI.java
+++ b/Common/src/main/java/subaraki/paintings/gui/IPaintingGUI.java
@@ -1,14 +1,14 @@
 package subaraki.paintings.gui;
 
 import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface IPaintingGUI {
-    List<Widget> getRenderablesWithCast();
+    List<Renderable> getRenderablesWithCast();
 
     Optional<AbstractWidget> optionalAbstractWidget(int index);
 

--- a/Common/src/main/java/subaraki/paintings/gui/PaintingButton.java
+++ b/Common/src/main/java/subaraki/paintings/gui/PaintingButton.java
@@ -4,7 +4,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.renderer.GameRenderer;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.decoration.PaintingVariant;
@@ -16,16 +16,16 @@ public class PaintingButton extends Button {
     private static final int YELLOW = -256;
 
     ResourceLocation resLoc;
-    private int animationY = 0;
+    private int animationY;
 
     public PaintingButton(int x, int y, int w, int h, Component text, OnPress onPress, PaintingVariant pt) {
-        super(x, y, w, h, text, onPress);
-        ResourceLocation rl = Registry.PAINTING_VARIANT.getKey(pt);
+        super(x, y, w, h, text, onPress, Button.DEFAULT_NARRATION);
+        ResourceLocation rl = BuiltInRegistries.PAINTING_VARIANT.getKey(pt);
         String combo = rl.getNamespace() + ":textures/painting/" + rl.getPath() + ".png";
         this.resLoc = new ResourceLocation(combo);
 
         animationY = height;
-        PaintingPackReader.PAINTINGS.stream().filter(paintingEntry -> paintingEntry.getResLoc().equals(rl.getPath()) && !resLoc.getNamespace().equals("minecraft")).findFirst().ifPresent(paintingEntry -> animationY = paintingEntry.getAnimY());
+        PaintingPackReader.PAINTINGS.stream().filter(paintingEntry -> paintingEntry.getResLoc().equals(rl) && !resLoc.getNamespace().equals("minecraft")).findFirst().ifPresent(paintingEntry -> animationY = paintingEntry.getAnimY());
     }
 
     @Override
@@ -35,22 +35,22 @@ public class PaintingButton extends Button {
         RenderSystem.setShaderTexture(0, resLoc);
 
         //blit(stack, this.x, this.y, 0, 0, width, 16, width, 16);
-        blit(stack, this.x, this.y, width, height, 0, 0, width, height, width, animationY);
+        blit(stack, this.getX(), this.getY(), width, height, 0, 0, width, height, width, animationY);
 
         if (isHovered) {
-            fill(stack, x - BORDER, y - BORDER, x + width + BORDER, y, YELLOW); // upper left to upper right
-            fill(stack, x - BORDER, y + height, x + width + BORDER, y + height + BORDER, YELLOW); // lower left to lower right
-            fill(stack, x - BORDER, y, x, y + height, YELLOW); // middle rectangle to the left
-            fill(stack, x + width, y, x + width + BORDER, y + height, YELLOW); // middle rectangle to the right
+            fill(stack, getX() - BORDER, getY() - BORDER, getX() + width + BORDER, getY(), YELLOW); // upper left to upper right
+            fill(stack, getX() - BORDER, getY() + height, getX() + width + BORDER, getY() + height + BORDER, YELLOW); // lower left to lower right
+            fill(stack, getX() - BORDER, getY(), getX(), getY() + height, YELLOW); // middle rectangle to the left
+            fill(stack, getX() + width, getY(), getX() + width + BORDER, getY() + height, YELLOW); // middle rectangle to the right
         }
 
     }
 
     public void shiftY(int dy) {
-        this.y += dy;
+        this.setY(this.getY() + dy);
     }
 
     public void shiftX(int dx) {
-        this.x += dx;
+        this.setX(this.getX() + dx);
     }
 }

--- a/Common/src/main/java/subaraki/paintings/gui/PaintingButton.java
+++ b/Common/src/main/java/subaraki/paintings/gui/PaintingButton.java
@@ -29,7 +29,7 @@ public class PaintingButton extends Button {
     }
 
     @Override
-    public void renderButton(PoseStack stack, int mouseX, int mouseY, float partialTicks) {
+    public void renderWidget(PoseStack stack, int mouseX, int mouseY, float partialTicks) {
         RenderSystem.setShader(GameRenderer::getPositionTexShader);
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.setShaderTexture(0, resLoc);
@@ -43,7 +43,6 @@ public class PaintingButton extends Button {
             fill(stack, getX() - BORDER, getY(), getX(), getY() + height, YELLOW); // middle rectangle to the left
             fill(stack, getX() + width, getY(), getX() + width + BORDER, getY() + height, YELLOW); // middle rectangle to the right
         }
-
     }
 
     public void shiftY(int dy) {

--- a/Common/src/main/java/subaraki/paintings/network/ProcessClientPacket.java
+++ b/Common/src/main/java/subaraki/paintings/network/ProcessClientPacket.java
@@ -1,6 +1,6 @@
 package subaraki.paintings.network;
 
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.Painting;
@@ -18,14 +18,14 @@ public class ProcessClientPacket {
         {
             Entity entity = ClientReferences.getClientPlayer().level.getEntity(entityID);
             if (entity instanceof Painting painting) {
-                PaintingVariant type = Registry.PAINTING_VARIANT.get(new ResourceLocation(possibleVariantNames[0]));
+                PaintingVariant type = BuiltInRegistries.PAINTING_VARIANT.get(new ResourceLocation(possibleVariantNames[0]));
                 subaraki.paintings.Paintings.UTILITY.setArt(painting, type);
                 Paintings.UTILITY.updatePaintingBoundingBox(painting);
 
             }
         } else // we need to open the painting gui to select a painting
         {
-            PaintingVariant[] types = Arrays.stream(possibleVariantNames).map(path -> Registry.PAINTING_VARIANT.get(new ResourceLocation(path))).toArray(PaintingVariant[]::new);
+            PaintingVariant[] types = Arrays.stream(possibleVariantNames).map(path -> BuiltInRegistries.PAINTING_VARIANT.get(new ResourceLocation(path))).toArray(PaintingVariant[]::new);
             ClientReferences.openPaintingScreen(screen.make(types, entityID));
         }
     }

--- a/Common/src/main/java/subaraki/paintings/network/ProcessServerPacket.java
+++ b/Common/src/main/java/subaraki/paintings/network/ProcessServerPacket.java
@@ -1,6 +1,6 @@
 package subaraki.paintings.network;
 
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
@@ -14,7 +14,7 @@ public class ProcessServerPacket {
     public static void handle(Level level, ServerPlayer player, int entityId, ResourceLocation paintingName, SyncpacketSupplier packet) {
         Entity entity = level.getEntity(entityId);
         if (entity instanceof Painting painting) {
-            PaintingVariant variant = Registry.PAINTING_VARIANT.get(paintingName);
+            PaintingVariant variant = BuiltInRegistries.PAINTING_VARIANT.get(paintingName);
             subaraki.paintings.Paintings.UTILITY.setArt(painting, variant);
             Paintings.UTILITY.updatePaintingBoundingBox(painting);
             packet.send(painting, player);

--- a/Common/src/main/java/subaraki/paintings/utils/PaintingUtility.java
+++ b/Common/src/main/java/subaraki/paintings/utils/PaintingUtility.java
@@ -1,7 +1,7 @@
 package subaraki.paintings.utils;
 
 import net.minecraft.core.Direction;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.decoration.HangingEntity;
 import net.minecraft.world.entity.decoration.Painting;
@@ -46,7 +46,7 @@ public class PaintingUtility {
     public void setArt(Painting painting, PaintingVariant type) {
         CompoundTag tag = new CompoundTag();
         painting.addAdditionalSaveData(tag);
-        String name = Registry.PAINTING_VARIANT.getKey(type).toString();
+        String name = BuiltInRegistries.PAINTING_VARIANT.getKey(type).toString();
         tag.putString("variant", name);
         painting.readAdditionalSaveData(tag);
     }

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     }
     modImplementation "com.terraformersmc:modmenu:${mod_menu_version}"
     implementation project(":Common")
-    modImplementation "${compat_mod}${compat_fabric}"
+//    modImplementation "${compat_mod}${compat_fabric}"
 
     modApi group: 'com.electronwill.night-config', name: 'core', version: '3.6.5'//Used for Global Packs compat, Global Packs ships this
 }

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -32,7 +32,8 @@ dependencies {
     }
     modImplementation "com.terraformersmc:modmenu:${mod_menu_version}"
     implementation project(":Common")
-//    modImplementation "${compat_mod}${compat_fabric}"
+    modRuntimeOnly "${transparent_mod}${transparent_fabric}"
+    modRuntimeOnly "${ash_mod}${ash_fabric}"
 
     modApi group: 'com.electronwill.night-config', name: 'core', version: '3.6.5'//Used for Global Packs compat, Global Packs ships this
 }
@@ -101,16 +102,16 @@ publishing {
 }
 
 task publishCurseForge(type: TaskPublishCurseForge) {
+    if (project.hasProperty('api_token_paintings')) {
+        apiToken = "${api_token_paintings}"
 
-    apiToken = "${api_token_paintings}"
-
-    // The main file to upload
-    def mainFile = upload(252042, file("${project.buildDir}/libs/${archivesBaseName}-${version}.jar"))
-    mainFile.releaseType = 'beta'
-    mainFile.changelog = "${changelog}"
-    mainFile.changelogType = 'markdown'
-    mainFile.addRequirement('transparent')
-    mainFile.addRequirement('cloth-config')
-    mainFile.addRequirement('fabric-api')
-
+        // The main file to upload
+        def mainFile = upload(252042, file("${project.buildDir}/libs/${archivesBaseName}-${version}.jar"))
+        mainFile.releaseType = 'beta'
+        mainFile.changelog = "${changelog}"
+        mainFile.changelogType = 'markdown'
+        mainFile.addRequirement('transparent')
+        mainFile.addRequirement('cloth-config')
+        mainFile.addRequirement('fabric-api')
+    }
 }

--- a/Fabric/src/main/java/subaraki/paintings/events/Events.java
+++ b/Fabric/src/main/java/subaraki/paintings/events/Events.java
@@ -5,7 +5,7 @@ import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
@@ -25,14 +25,14 @@ public class Events {
     }
 
     private static boolean equalNames(PaintingVariant a, PaintingVariant b) {
-        return Registry.PAINTING_VARIANT.getKey(a).equals(Registry.PAINTING_VARIANT.getKey(b));
+        return BuiltInRegistries.PAINTING_VARIANT.getKey(a).equals(BuiltInRegistries.PAINTING_VARIANT.getKey(b));
     }
 
     public static void events() {
         UseEntityCallback.EVENT.register((player, world, hand, target, hitResult) -> {
 
             SyncpacketSupplier packetSupplier = (painting, serverPlayer) -> {
-                FriendlyByteBuf byteBuf = ClientNetwork.cPacket(painting.getId(), new String[]{Registry.PAINTING_VARIANT.getKey(painting.getVariant().value()).toString()});
+                FriendlyByteBuf byteBuf = ClientNetwork.cPacket(painting.getId(), new String[]{BuiltInRegistries.PAINTING_VARIANT.getKey(painting.getVariant().value()).toString()});
                 for (ServerPlayer tracking : PlayerLookup.tracking(serverPlayer)) {
                     ServerPlayNetworking.send(tracking, PacketId.CHANNEL, byteBuf);
                 }

--- a/Fabric/src/main/java/subaraki/paintings/gui/PaintingScreen.java
+++ b/Fabric/src/main/java/subaraki/paintings/gui/PaintingScreen.java
@@ -2,7 +2,7 @@ package subaraki.paintings.gui;
 
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.decoration.PaintingVariant;
 import subaraki.paintings.mixins.ScreenAccessor;
@@ -20,7 +20,7 @@ public class PaintingScreen extends CommonPaintingScreen {
 
     @Override
     public Optional<AbstractWidget> optionalAbstractWidget(int index) {
-        Widget w = getRenderablesWithCast().get(index);
+        Renderable w = getRenderablesWithCast().get(index);
         if (w instanceof AbstractWidget aw)
             return Optional.of(aw);
         return Optional.empty();
@@ -31,7 +31,7 @@ public class PaintingScreen extends CommonPaintingScreen {
         ClientPlayNetworking.send(PacketId.CHANNEL, ServerNetwork.sPacket(entityId, variantName));
     }
 
-    public List<Widget> getRenderablesWithCast() {
+    public List<Renderable> getRenderablesWithCast() {
         return ((ScreenAccessor) this).getRenderables();
     }
 }

--- a/Fabric/src/main/java/subaraki/paintings/mixins/ScreenAccessor.java
+++ b/Fabric/src/main/java/subaraki/paintings/mixins/ScreenAccessor.java
@@ -1,6 +1,6 @@
 package subaraki.paintings.mixins;
 
-import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.screens.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -10,5 +10,5 @@ import java.util.List;
 @Mixin(Screen.class)
 public interface ScreenAccessor {
     @Accessor("renderables")
-    List<Widget> getRenderables();
+    List<Renderable> getRenderables();
 }

--- a/Fabric/src/main/java/subaraki/paintings/mod/Paintings.java
+++ b/Fabric/src/main/java/subaraki/paintings/mod/Paintings.java
@@ -5,6 +5,7 @@ import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.ResourceLocationException;
 import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.decoration.PaintingVariant;
 import subaraki.paintings.events.Events;
 import subaraki.paintings.network.ServerNetwork;
@@ -16,18 +17,18 @@ import static subaraki.paintings.Paintings.LOGGER;
 
 public class Paintings implements ModInitializer {
 
+    public static ModConfig config;
+
     /* call init here, to read json files before any event is launched. */
     static {
         new PaintingPackReader().init();
     }
 
-    public static ModConfig config;
-
     @Override
     public void onInitialize() {
         try {
             for (PaintingEntry entry : PaintingPackReader.PAINTINGS) {
-                Registry.register(Registry.PAINTING_VARIANT, entry.getResLoc(), new PaintingVariant(entry.getSizeX(), entry.getSizeY()));
+                Registry.register(BuiltInRegistries.PAINTING_VARIANT, entry.getResLoc(), new PaintingVariant(entry.getSizeX(), entry.getSizeY()));
                 LOGGER.info("Registered painting " + entry.getPaintingName());
             }
         } catch (ResourceLocationException e) {

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -90,9 +90,10 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compileOnly project(":Common")
     annotationProcessor 'org.spongepowered:mixin:0.8.4-SNAPSHOT:processor'
-//    runtimeOnly fg.deobf("${compat_mod}${compat_forge}")
-
+    runtimeOnly fg.deobf("${transparent_mod}${transparent_forge}")
+    runtimeOnly fg.deobf("${ash_mod}${ash_forge}")
 }
+
 repositories { //all of these are for adding crates compat
     mavenLocal()
     maven {
@@ -136,13 +137,14 @@ publishing {
 }
 
 task publishCurseForge(type: TaskPublishCurseForge) {
+    if (project.hasProperty('api_token_paintings')) {
+        apiToken = "${api_token_paintings}"
 
-    apiToken = "${api_token_paintings}"
-
-    // The main file to upload
-    def mainFile = upload(252042, jar)
-    mainFile.releaseType = 'beta'
-    mainFile.changelog = "${changelog}"
-    mainFile.changelogType = 'markdown'
-    mainFile.addRequirement('transparent')
+        // The main file to upload
+        def mainFile = upload(252042, jar)
+        mainFile.releaseType = 'beta'
+        mainFile.changelog = "${changelog}"
+        mainFile.changelogType = 'markdown'
+        mainFile.addRequirement('transparent')
+    }
 }

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compileOnly project(":Common")
     annotationProcessor 'org.spongepowered:mixin:0.8.4-SNAPSHOT:processor'
-    runtimeOnly fg.deobf("${compat_mod}${compat_forge}")
+//    runtimeOnly fg.deobf("${compat_mod}${compat_forge}")
 
 }
 repositories { //all of these are for adding crates compat

--- a/Forge/src/main/java/subaraki/paintings/datagen/Generator.java
+++ b/Forge/src/main/java/subaraki/paintings/datagen/Generator.java
@@ -1,6 +1,7 @@
 package subaraki.paintings.datagen;
 
-import net.minecraft.core.Registry;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.tags.PaintingVariantTagsProvider;
 import net.minecraft.resources.ResourceKey;
@@ -15,15 +16,21 @@ import subaraki.paintings.utils.PaintingPackReader;
 @Mod.EventBusSubscriber(modid = Paintings.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class Generator {
 
+    // Apologise if this doesn't work. I've never used Forge's data generators before, but it compiles.
     @SubscribeEvent
     public static void gatherData(GatherDataEvent event) {
         DataGenerator generator = event.getGenerator();
 
-        generator.addProvider(event.includeServer(), new PaintingVariantTagsProvider(generator, Paintings.MODID, event.getExistingFileHelper()) {
+        generator.addProvider(event.includeServer(), new PaintingVariantTagsProvider(
+                event.getGenerator().getPackOutput(),
+                event.getLookupProvider(),
+                Paintings.MODID,
+                event.getExistingFileHelper()
+        ) {
             @Override
-            protected void addTags() {
+            protected void addTags(HolderLookup.Provider provider) {
                 for (PaintingEntry entry : PaintingPackReader.PAINTINGS)
-                    this.tag(PaintingVariantTags.PLACEABLE).add(ResourceKey.create(Registry.PAINTING_VARIANT_REGISTRY, entry.getResLoc()));
+                    this.tag(PaintingVariantTags.PLACEABLE).add(ResourceKey.create(Registries.PAINTING_VARIANT, entry.getResLoc()));
             }
         });
     }

--- a/Forge/src/main/java/subaraki/paintings/event/PaintingInteractEvent.java
+++ b/Forge/src/main/java/subaraki/paintings/event/PaintingInteractEvent.java
@@ -1,12 +1,12 @@
 package subaraki.paintings.event;
 
-import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.network.PacketDistributor;
+import net.minecraftforge.registries.ForgeRegistries;
 import subaraki.paintings.network.NetworkHandler;
 import subaraki.paintings.network.client.CPacketPainting;
 
@@ -17,6 +17,6 @@ public class PaintingInteractEvent {
     public static void interact(PlayerInteractEvent.EntityInteract event) {
         ProcessInteractEvent.processInteractPainting(event.getEntity(), event.getTarget(), event.getHand(),
                 (painting, player) -> NetworkHandler.NETWORK.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with((() -> player)),
-                        new CPacketPainting(painting, new ResourceLocation[]{Registry.PAINTING_VARIANT.getKey(painting.getVariant().get())})));
+                        new CPacketPainting(painting, new ResourceLocation[]{ForgeRegistries.PAINTING_VARIANTS.getKey(painting.getVariant().get())})));
     }
 }

--- a/Forge/src/main/java/subaraki/paintings/gui/PaintingScreen.java
+++ b/Forge/src/main/java/subaraki/paintings/gui/PaintingScreen.java
@@ -1,7 +1,7 @@
 package subaraki.paintings.gui;
 
 import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.decoration.PaintingVariant;
 import subaraki.paintings.network.NetworkHandler;
@@ -20,7 +20,7 @@ public class PaintingScreen extends CommonPaintingScreen {
     @Override
     public Optional<AbstractWidget> optionalAbstractWidget(int index) {
         if (index < renderables.size()) {//if index is within of bounds
-            Widget w = renderables.get(index);
+            Renderable w = renderables.get(index);
             if (w instanceof AbstractWidget aw)
                 return Optional.of(aw);
         }
@@ -34,7 +34,7 @@ public class PaintingScreen extends CommonPaintingScreen {
     }
 
     @Override
-    public List<Widget> getRenderablesWithCast() {
+    public List<Renderable> getRenderablesWithCast() {
         return renderables;
     }
 }

--- a/Forge/src/main/java/subaraki/paintings/mod/PackForcer.java
+++ b/Forge/src/main/java/subaraki/paintings/mod/PackForcer.java
@@ -1,11 +1,13 @@
 package subaraki.paintings.mod;
 
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.FilePackResources;
-import net.minecraft.server.packs.FolderPackResources;
 import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.PathPackResources;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraft.server.packs.repository.RepositorySource;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -14,11 +16,6 @@ import subaraki.paintings.utils.PaintingPackReader;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.function.Consumer;
 
 @Mod.EventBusSubscriber(modid = Paintings.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -33,14 +30,34 @@ public class PackForcer implements RepositorySource {
     }
 
     @Override
-    public void loadPacks(Consumer<Pack> packConsumer, Pack.PackConstructor packBuilder) {
+    public void loadPacks(Consumer<Pack> packConsumer) {
         File dir = new File("./resourcepacks");
         if (dir.isDirectory()) {
             File[] fashionPacks = dir.listFiles(RESOURCEPACK_FILTER);
             if (fashionPacks != null)
                 for (File directory : fashionPacks) {
-                    Pack zipPack = Pack.create("file/" + directory.getName(), true, () -> new FilePackResources(directory), packBuilder, Pack.Position.TOP, PackSource.DEFAULT);
-                    Pack folderPack = Pack.create("file/" + directory.getName(), true, () -> new FolderPackResources(directory), packBuilder, Pack.Position.TOP, PackSource.DEFAULT);
+                    Pack zipPack = Pack.create(
+                            "file/" + directory.getName(),
+                            Component.literal(directory.getName()),
+                            true,
+                            id -> new FilePackResources(directory.getName(), directory, false),
+                            new Pack.Info(Component.empty(), 12, FeatureFlagSet.of()),
+                            PackType.CLIENT_RESOURCES,
+                            Pack.Position.TOP,
+                            false,
+                            PackSource.DEFAULT
+                    );
+                    Pack folderPack = Pack.create(
+                            "file/" + directory.getName(),
+                            Component.literal(directory.getName()),
+                            true,
+                            id -> new PathPackResources(directory.getName(), directory.toPath(), false),
+                            new Pack.Info(Component.empty(), 12, FeatureFlagSet.of()),
+                            PackType.CLIENT_RESOURCES,
+                            Pack.Position.TOP,
+                            false,
+                            PackSource.DEFAULT
+                    );
 
                     if (zipPack != null) {
                         packConsumer.accept(zipPack);

--- a/Forge/src/main/java/subaraki/paintings/mod/Paintings.java
+++ b/Forge/src/main/java/subaraki/paintings/mod/Paintings.java
@@ -2,7 +2,7 @@ package subaraki.paintings.mod;
 
 
 import net.minecraft.ResourceLocationException;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.entity.decoration.PaintingVariant;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -36,7 +36,7 @@ public class Paintings {
 
     @SubscribeEvent
     public static void registerPaintigns(RegisterEvent event) {
-        event.register(Registry.PAINTING_VARIANT_REGISTRY, registry -> {
+        event.register(Registries.PAINTING_VARIANT, registry -> {
             for (PaintingEntry entry : PaintingPackReader.PAINTINGS) {
                 try {
                     registry.register(entry.getResLoc(), new PaintingVariant(entry.getSizeX(), entry.getSizeY()));

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,19 @@
 version=10.2.4.0
 changelog=Folders can now be read as pack. Uploads happen automatically. Fix forced packs not working
 group=subaraki.paintings
-
 # Common
-minecraft_version=1.19.2
+minecraft_version=1.19.3
 common_runs_enabled=false
 common_client_run_name=Common Client
 common_server_run_name=Common Server
 # Forge
-forge_version=43.1.52
+forge_version=44.0.6
 //forge_ats_enabled=true
 # Fabric
-fabric_version=0.64.0+1.19.2
-fabric_loader_version=0.14.10
-cloth_config_version=8.2.88
-mod_menu_version=4.1.0
+fabric_version=0.68.1+1.19.3
+fabric_loader_version=0.14.11
+cloth_config_version=9.0.94
+mod_menu_version=5.0.2
 # Mod options
 mod_name=Paintings
 mod_author=Subaraki

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,10 @@ mod_id=paintings
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 # compat with the 'transparent' mod
-#file id's from the cursemaven
-compat_mod=curse.maven:transparent-377582:
-compat_forge= 3834254
-compat_fabric=3834255
+transparent_mod=curse.maven:transparent-377582:
+transparent_forge= 4503226
+transparent_fabric=4503227
+# 'transparent' mod now requires ash-api
+ash_mod=curse.maven:ash-api-838498:
+ash_forge= 4505414
+ash_fabric=4505415

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,18 @@ version=10.2.4.0
 changelog=Folders can now be read as pack. Uploads happen automatically. Fix forced packs not working
 group=subaraki.paintings
 # Common
-minecraft_version=1.19.3
+minecraft_version=1.19.4
 common_runs_enabled=false
 common_client_run_name=Common Client
 common_server_run_name=Common Server
 # Forge
-forge_version=44.0.6
+forge_version=45.0.49
 //forge_ats_enabled=true
 # Fabric
-fabric_version=0.68.1+1.19.3
-fabric_loader_version=0.14.11
-cloth_config_version=9.0.94
-mod_menu_version=5.0.2
+fabric_version=0.79.0+1.19.4
+fabric_loader_version=0.14.19
+cloth_config_version=10.0.96
+mod_menu_version=6.2.1
 # Mod options
 mod_name=Paintings
 mod_author=Subaraki


### PR DESCRIPTION
The 1.19.3 PR does not work on 1.19.4, so I also ported Paintings++ to 1.19.4.

Only the method `renderButton` had to be changed to `renderWidget`.

In 1.19.4 Mojang also added painting variants to the creative tabs, so I added some code so that when placing these variants the Paintings++ gui does not pop up because the user clearly wants that specific painting.
<img width="584" alt="image" src="https://user-images.githubusercontent.com/29845000/234375703-187e585d-f383-4cdc-8342-cfc42205a6cd.png">

Finally, I looked into possibly adding Paintings++ paintings to the creative menu. It seems like the only thing stopping that from happening already is that Paintings++ paintings aren't in the `placeable` painting variant tag. I don't know if it's easy to add entries to a tag at runtime, and I think the result would just be overwhelming the user with painting items in that creative tab so I decided to not look into it further. But if you or someone else is interested, that's where I'd look first.